### PR TITLE
Fix for incorrect execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 # Add the current directory contents into the container at /app
 ADD . /app
 
-# Install curl, jq and create directory
+# Install curl and other dependencies
 RUN apk --no-cache add curl curl-dev gcc musl-dev linux-headers jq && mkdir -p /app/edgar_data
 
 # Install any needed packages specified in requirements.txt
@@ -19,11 +19,11 @@ RUN chmod +x /app/scripts/entrypoint.sh
 # Run makedb.py to create the database cache
 RUN python makedb.py
 
+# Set environment variable for production
+ENV ENVIRONMENT=production
+
 # Make port 8000 available to the world outside this container
 EXPOSE 8000
-
-# Set default host if not provided
-ENV COMPANY_DNS_HOST=company-dns.mediumroast.io
 
 # Use entrypoint script to configure hosts
 ENTRYPOINT ["/app/scripts/entrypoint.sh"]

--- a/company_dns.py
+++ b/company_dns.py
@@ -355,14 +355,19 @@ app = Starlette(debug=True, middleware=middleware, routes=[
 
 if __name__ == "__main__": 
     try:
-        # Change these parameters to be more explicit about logging
+        # In development (local)
+        if os.environ.get('ENVIRONMENT') == 'dev':
+            host = '127.0.0.1'
+        else:
+            # In production (container)
+            host = '0.0.0.0'  # Accept connections from any IP
+            
         uvicorn.run(
             app, 
-            host='127.0.0.1',  # Change from 0.0.0.0 to 127.0.0.1 for local testing
+            host=host,
             port=8000, 
-            log_level='debug',  # Increase log level to see more details
-            access_log=True,    # Ensure access logs are enabled
-            lifespan='off'
+            log_level='info',
+            access_log=True
         )
     except KeyboardInterrupt:
         logger.info("Server was shut down by the user.")


### PR DESCRIPTION
attempting to resolve the issue:

```upstream connect error or disconnect/reset before headers. retried and the latest reset reason: remote connection failure, transport failure reason: delayed connect error: 111```

This appeared to be because we were binding to localhost only.